### PR TITLE
Add sbt-revolver plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"             % "0.8.5")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager" % "1.1.0-RC3")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"          % "1.5.1")
+addSbtPlugin("io.spray"          % "sbt-revolver"        % "0.8.0")
 addSbtPlugin("org.scalariform"   % "sbt-scalariform"     % "1.6.0")


### PR DESCRIPTION
Thanks for the demo! I was greeted with `[error] Not a valid command: reStart` when running the sample commands; I'm guessing you use ~/.sbt/[...]/plugins.sbt to setup revolver, so this is broken for users that don't.